### PR TITLE
Update setup.py for use as a library

### DIFF
--- a/climada/util/hdf5_handler.py
+++ b/climada/util/hdf5_handler.py
@@ -86,7 +86,7 @@ def get_string(array):
         Returns:
             string
     """
-    return u''.join(chr(c) for c in array)
+    return u''.join(chr(int(c)) for c in array)
 
 def get_str_from_ref(file_name, var):
     """Form string from a reference HDF5 variable of the given file.

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         'tabulate>=0.8.3',
         'toolz', # < dask
         'tqdm>=4.31.1',
-        'xarray>=0.12.1',
+        'xarray==0.12.1',
         'xlrd', # < pandas
         'xlsxwriter>=1.1.7',
         'xmlrunner>=1.7.7', # ci tests

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'elevation>=1.0.6',
         'fiona>=1.8.4',
         'fsspec>=0.3.6', # < dask
-        'gdal>=2.3.3', # conda!
+        'gdal==3.0.4', # conda!
         'geopandas>=0.4.1',
         'h5py>=2.9.0',
         'haversine>=2.1.1',

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'numba>=0.43.1', # conda!
         'numpy>=1.16.3', # conda+
         'overpy>=0.4',
-        'pandas>=0.24.2',
+        'pandas>=0.23.4',
         'pandas_datareader>=0.7.0',
         'pathos>=0.2.3',
         'pillow>=7.0', # PIL

--- a/setup.py
+++ b/setup.py
@@ -54,51 +54,46 @@ setup(
     packages=find_packages(where='.'),
 
     install_requires=[
-        'cartopy==0.17.0', # conda!
         'cloudpickle', # install_test
-        'contextily==1.0rc2',
-        'dask==1.2.2',
+        'contextily>=1.0rc2',
+        'dask>=1.2.2',
         'descartes',
-        #'earthengine_api==0.1.210', # ee, conda!
-        'elevation==1.0.6',
-        'fiona==1.8.4',
+        'elevation>=1.0.6',
+        'fiona>=1.8.4',
         'fsspec>=0.3.6', # < dask
-        'gdal==2.3.3', # conda!
-        'geopandas==0.4.1',
-        'h5py==2.9.0',
-        'haversine==2.1.1',
-        'iso3166==1.0',
-        #'kealib==1.4.7', < fiona
-        'matplotlib==3.1', #
+        'gdal>=2.3.3', # conda!
+        'geopandas>=0.4.1',
+        'h5py>=2.9.0',
+        'haversine>=2.1.1',
+        'iso3166>=1.0',
+        'matplotlib>=3.1', #
         'mercantile',
-        #'mpl_toolkits', matplotlib
-        'netCDF4==1.4.2', # conda!
-        'numba==0.43.1', # conda!
-        'numpy==1.16.3', # conda+
-        'overpy==0.4',
-        'pandas==0.24.2',
-        'pandas_datareader==0.7.0',
-        'pathos==0.2.3',
-        'pillow==7.0', # PIL
-        'pint==0.9',
-        #'pylab', matplotlib
-        'pyproj==1.9.6', #
+        'netCDF4>=1.4.1', # conda!
+        'numba>=0.43.1', # conda!
+        'numpy>=1.16.3', # conda+
+        'overpy>=0.4',
+        'pandas>=0.24.2',
+        'pandas_datareader>=0.7.0',
+        'pathos>=0.2.3',
+        'pillow>=7.0', # PIL
+        'pint>=0.9',
+        'pyproj>=1.9.6', #
         'pyshp', # shapefile
-        'rasterio==1.0.21',
-        'requests==2.21.0', #
-        'rtree==0.8.3', # < geopandas.overlay
-        'scikit-learn==0.20.3', # sklearn
-        'scipy==1.2.1', # conda+
-        'shapely==1.6.4', #
-        'six==1.13.0', #
+        'rasterio>=1.0.21',
+        'requests>=2.21.0', #
+        'rtree>=0.8.3', # < geopandas.overlay
+        'scikit-learn>=0.20.3', # sklearn
+        'scipy>=1.2.1', # conda+
+        'shapely>=1.6.4', #
+        'six>=1.13.0', #
         'tables', # < pandas (climada.entity.measures.test.test_base.TestApply)
-        'tabulate==0.8.3',
+        'tabulate>=0.8.3',
         'toolz', # < dask
-        'tqdm==4.31.1',
-        'xarray==0.12.1',
+        'tqdm>=4.31.1',
+        'xarray>=0.12.1',
         'xlrd', # < pandas
-        'xlsxwriter==1.1.7',
-        'xmlrunner==1.7.7', # ci tests
+        'xlsxwriter>=1.1.7',
+        'xmlrunner>=1.7.7', # ci tests
     ],
 
     package_data={'': extra_files},


### PR DESCRIPTION
There are three changes here:
1. Make all `==` requirements `>=` requirements. Rather than specify an exact version, libraries should specify version ranges that they are expected to work with.
2. Remove cartopy because it breaks automation & we already handle it elsehow
3. Bump the patch version of `netCDF4` to `1.4.2` instead of `1.4.1` to align with Lab.